### PR TITLE
Add external docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ The server runs over stdio only and waits for requests from an MCP-aware client 
 
 The `claude_desktop_config.json` file includes an example entry pointing to the `complaints.py` script. Replace `INSERTPATH` with the path to this repository on your machine and import the configuration into Claude Desktop.
 
+
+## References
+
+- [CFPB Consumer Complaint Database API documentation](https://cfpb.github.io/ccdb5-api/documentation/) – underlying API used by this MCP server.
+- [Model Context Protocol quickstart tutorial](https://modelcontextprotocol.io/quickstart/server) – tutorial that helped build this example.


### PR DESCRIPTION
## Summary
- document the CFPB API docs this MCP uses
- mention the MCP server tutorial used as reference

## Testing
- `python -m py_compile complaints.py`
- `python complaints.py --help | head` *(fails: ModuleNotFoundError: No module named 'httpx')*